### PR TITLE
impl import_task

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,12 +15,16 @@ pub enum TaskErrorKind {
 
     /// Error kind indicating that the Status of a task is missing
     NoStatus,
+
+    /// Error kind indicating that the Reader failed to read something
+    ReaderError,
 }
 
 fn store_error_type_as_str(e: &TaskErrorKind) -> &'static str {
     match e {
         &TaskErrorKind::ParserError => "Parser Error",
         &TaskErrorKind::NoStatus    => "Task status is missing",
+        &TaskErrorKind::ReaderError => "Reader Error",
     }
 }
 

--- a/src/import.rs
+++ b/src/import.rs
@@ -17,6 +17,14 @@ pub fn import<R: Read>(r: R) -> Result<Vec<Task>> {
         })
 }
 
+/// Import a single JSON-formatted Task
+pub fn import_task(s : &str) -> Result<Task> {
+    serde_json::from_str(s)
+        .map_err(|e| {
+            TaskError::new(TaskErrorKind::ParserError, Some(Box::new(e)))
+        })
+}
+
 #[test]
 fn test_one() {
     let s = r#"
@@ -98,3 +106,27 @@ fn test_two() {
     let imported = imported.unwrap();
     assert!(imported.len() == 3);
 }
+
+#[test]
+fn test_one_single() {
+    use status::TaskStatus;
+    let s = r#"
+{
+    "id": 1,
+    "description": "some description",
+    "entry": "20150619T165438Z",
+    "modified": "20160327T164007Z",
+    "project": "someproject",
+    "status": "waiting",
+    "tags": ["some", "tags", "are", "here"],
+    "uuid": "8ca953d5-18b4-4eb9-bd56-18f2e5b752f0",
+    "wait": "20160508T164007Z",
+    "urgency": 0.583562
+}
+"#;
+    let imported = import_task(&s);
+    assert!(imported.is_ok());
+    let imported = imported.unwrap();
+    assert!(imported.status() == &TaskStatus::Waiting);
+}
+


### PR DESCRIPTION
Hey, i just implemented it for &str. it might be useful to also implement it like
```
pub fn import_tasks(r : Read) -> Result<Vec<Task>>;
```
with line splitting in the function. I think the BufReader might be required for this, so maybe instead of `r : Read` a `r : BufRead`, or maybe it is possible to construct a BufRead from a Read.