### PR TITLE
Update version of task-hookrs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "task-hookrs"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>",
            "Mario Krehl <mario-krehl@gmx.de>",
           ]


### PR DESCRIPTION
Update version to 0.3.0

Superceeds #44 