### PR TITLE
Update: uuid: 0.4 -> 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-uuid = { version = "0.5", features = ["serde"] }
+uuid = { version = "0.6", features = ["serde"] }
 
 [dev-dependencies]
 env_logger = "0.4"


### PR DESCRIPTION
New release of uuid... 

We should release this as a new version of `task-hookrs`, right?