### PR TITLE
[after support-uda] Apply rustfmt

### DIFF
--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -14,11 +14,10 @@ use date::Date;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Annotation {
     entry: Date,
-    description: String
+    description: String,
 }
 
 impl Annotation {
-
     /// Create a new Annotation object
     pub fn new(entry: Date, description: String) -> Annotation {
         Annotation {
@@ -46,9 +45,7 @@ impl Annotation {
     pub fn description_mut(&mut self) -> &mut String {
         &mut self.description
     }
-
 }
 
 #[cfg(test)]
-mod test {
-}
+mod test {}

--- a/src/date.rs
+++ b/src/date.rs
@@ -27,43 +27,37 @@ impl Deref for Date {
     fn deref(&self) -> &NaiveDateTime {
         &self.0
     }
-
 }
 
 impl DerefMut for Date {
-
     fn deref_mut(&mut self) -> &mut NaiveDateTime {
         &mut self.0
     }
-
 }
 
 impl From<NaiveDateTime> for Date {
-
     fn from(ndt: NaiveDateTime) -> Date {
         Date(ndt)
     }
-
 }
 
 /// The date-time parsing template used to parse the date time data exported by taskwarrior.
-pub static TASKWARRIOR_DATETIME_TEMPLATE : &'static str = "%Y%m%dT%H%M%SZ";
+pub static TASKWARRIOR_DATETIME_TEMPLATE: &'static str = "%Y%m%dT%H%M%SZ";
 
 impl Serialize for Date {
-
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         let formatted = self.0.format(TASKWARRIOR_DATETIME_TEMPLATE);
         serializer.serialize_str(&format!("{}", formatted))
     }
-
 }
 
 impl<'de> Deserialize<'de> for Date {
-
     fn deserialize<D>(deserializer: D) -> Result<Date, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         struct DateVisitor;
 
@@ -71,11 +65,16 @@ impl<'de> Deserialize<'de> for Date {
             type Value = Date;
 
             fn expecting(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                write!(fmt, "a string which matches {}", TASKWARRIOR_DATETIME_TEMPLATE)
+                write!(
+                    fmt,
+                    "a string which matches {}",
+                    TASKWARRIOR_DATETIME_TEMPLATE
+                )
             }
 
             fn visit_str<E>(self, value: &str) -> Result<Date, E>
-                where E: SerdeError
+            where
+                E: SerdeError,
             {
                 NaiveDateTime::parse_from_str(value, TASKWARRIOR_DATETIME_TEMPLATE)
                     .map(|d| Date(d))
@@ -85,5 +84,4 @@ impl<'de> Deserialize<'de> for Date {
 
         deserializer.deserialize_str(DateVisitor)
     }
-
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,18 +29,16 @@ pub enum TaskErrorKind {
 fn store_error_type_as_str(e: &TaskErrorKind) -> &'static str {
     match e {
         &TaskErrorKind::ParserError => "Parser Error",
-        &TaskErrorKind::NoStatus    => "Task status is missing",
+        &TaskErrorKind::NoStatus => "Task status is missing",
         &TaskErrorKind::ReaderError => "Reader Error",
     }
 }
 
 impl Display for TaskErrorKind {
-
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), FmtError> {
         try!(write!(fmt, "{}", store_error_type_as_str(self)));
         Ok(())
     }
-
 }
 
 ///
@@ -53,18 +51,15 @@ pub struct TaskError {
 }
 
 impl TaskError {
-
     ///
     /// Build a new TaskError from an TaskErrorKind, optionally with cause
     ///
-    pub fn new(errtype: TaskErrorKind, cause: Option<Box<Error>>)
-        -> TaskError
-        {
-            TaskError {
-                err_type: errtype,
-                cause: cause,
-            }
+    pub fn new(errtype: TaskErrorKind, cause: Option<Box<Error>>) -> TaskError {
+        TaskError {
+            err_type: errtype,
+            cause: cause,
         }
+    }
 
     ///
     /// Get the error type of this TaskError
@@ -72,20 +67,20 @@ impl TaskError {
     pub fn err_type(&self) -> TaskErrorKind {
         self.err_type.clone()
     }
-
 }
 
 impl Display for TaskError {
-
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), FmtError> {
-        try!(write!(fmt, "[{}]", store_error_type_as_str(&self.err_type.clone())));
+        try!(write!(
+            fmt,
+            "[{}]",
+            store_error_type_as_str(&self.err_type.clone())
+        ));
         Ok(())
     }
-
 }
 
 impl Error for TaskError {
-
     fn description(&self) -> &str {
         store_error_type_as_str(&self.err_type.clone())
     }
@@ -93,6 +88,4 @@ impl Error for TaskError {
     fn cause(&self) -> Option<&Error> {
         self.cause.as_ref().map(|e| &**e)
     }
-
 }
-

--- a/src/import.rs
+++ b/src/import.rs
@@ -18,26 +18,27 @@ use error::{TaskError, TaskErrorKind};
 /// Import taskwarrior-exported JSON. This expects an JSON Array of objects, as exported by
 /// taskwarrior.
 pub fn import<R: Read>(r: R) -> Result<Vec<Task>> {
-    serde_json::from_reader(r)
-        .map_err(|e| {
-            TaskError::new(TaskErrorKind::ParserError, Some(Box::new(e)))
-        })
+    serde_json::from_reader(r).map_err(|e| {
+        TaskError::new(TaskErrorKind::ParserError, Some(Box::new(e)))
+    })
 }
 
 /// Import a single JSON-formatted Task
-pub fn import_task(s : &str) -> Result<Task> {
-    serde_json::from_str(s)
-        .map_err(|e| {
-            TaskError::new(TaskErrorKind::ParserError, Some(Box::new(e)))
-        })
+pub fn import_task(s: &str) -> Result<Task> {
+    serde_json::from_str(s).map_err(|e| {
+        TaskError::new(TaskErrorKind::ParserError, Some(Box::new(e)))
+    })
 }
 
 /// Reads line by line and tries to parse a task-object per line.
-pub fn import_tasks<BR: BufRead>(r : BR) -> Vec<Result<Task>> {
+pub fn import_tasks<BR: BufRead>(r: BR) -> Vec<Result<Task>> {
     let mut vt = Vec::new();
     for line in r.lines() {
         if line.is_err() {
-            vt.push(Err(TaskError::new(TaskErrorKind::ReaderError, Some(Box::new(line.unwrap_err())))));
+            vt.push(Err(TaskError::new(
+                TaskErrorKind::ReaderError,
+                Some(Box::new(line.unwrap_err())),
+            )));
             continue;
         }
         // Unwrap is safe because of continue above
@@ -162,13 +163,16 @@ fn test_one_single() {
     assert!(task.status() == &TaskStatus::Waiting);
     assert!(task.description() == "some description");
     assert!(task.entry().clone() == mkdate("20150619T165438Z"));
-    assert!(task.uuid().clone() == Uuid::parse_str("8ca953d5-18b4-4eb9-bd56-18f2e5b752f0").unwrap());
+    assert!(
+        task.uuid().clone() == Uuid::parse_str("8ca953d5-18b4-4eb9-bd56-18f2e5b752f0").unwrap()
+    );
     assert!(task.modified() == Some(&mkdate("20160327T164007Z")));
     assert!(task.project() == Some(&String::from("someproject")));
     if let Some(tags) = task.tags() {
         for tag in tags {
-            let any_tag = [ "some", "tags", "are", "here", ]
-                .into_iter().any(|t| tag == *t);
+            let any_tag = ["some", "tags", "are", "here"].into_iter().any(
+                |t| tag == *t,
+            );
             assert!(any_tag, "Tag {} missing", tag);
         }
     } else {
@@ -194,4 +198,3 @@ fn test_two_single() {
     assert!(import0.status() == &TaskStatus::Waiting);
     assert!(import1.status() == &TaskStatus::Waiting);
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,4 +67,3 @@ pub mod status;
 pub mod tag;
 pub mod task;
 pub mod uda;
-

--- a/src/priority.rs
+++ b/src/priority.rs
@@ -21,4 +21,3 @@ pub enum TaskPriority {
     #[serde(rename = "H")]
     High,
 }
-

--- a/src/project.rs
+++ b/src/project.rs
@@ -8,4 +8,3 @@
 
 /// Typedef for Project type.
 pub type Project = String;
-

--- a/src/status.rs
+++ b/src/status.rs
@@ -29,19 +29,17 @@ pub enum TaskStatus {
 
     /// Recurring status type
     #[serde(rename = "recurring")]
-    Recurring
+    Recurring,
 }
 
 impl Display for TaskStatus {
-
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), FmtError> {
         match self {
-            &TaskStatus::Pending   => write!(fmt, "Pending"),
-            &TaskStatus::Deleted   => write!(fmt, "Deleted"),
+            &TaskStatus::Pending => write!(fmt, "Pending"),
+            &TaskStatus::Deleted => write!(fmt, "Deleted"),
             &TaskStatus::Completed => write!(fmt, "Completed"),
-            &TaskStatus::Waiting   => write!(fmt, "Waiting"),
+            &TaskStatus::Waiting => write!(fmt, "Waiting"),
             &TaskStatus::Recurring => write!(fmt, "Recurring"),
         }
     }
 }
-

--- a/src/task.rs
+++ b/src/task.rs
@@ -74,59 +74,57 @@ pub struct Task {
  * to us. I guess this should be fixed.
  */
 impl Task {
-
     /// Create a new Task instance
     pub fn new(
-        id          : Option<u64>,
+        id: Option<u64>,
 
-        status      : TaskStatus,
-        uuid        : Uuid,
-        entry       : Date,
-        description : String,
+        status: TaskStatus,
+        uuid: Uuid,
+        entry: Date,
+        description: String,
 
-        annotations : Option<Vec<Annotation>>,
-        depends     : Option<String>,
-        due         : Option<Date>,
-        end         : Option<Date>,
-        imask       : Option<i64>,
-        mask        : Option<String>,
-        modified    : Option<Date>,
-        parent      : Option<Uuid>,
-        priority    : Option<TaskPriority>,
-        project     : Option<Project>,
-        recur       : Option<String>,
-        scheduled   : Option<Date>,
-        start       : Option<Date>,
-        tags        : Option<Vec<Tag>>,
-        until       : Option<Date>,
-        wait        : Option<Date>,
-        uda         : UDA,
-    ) -> Task
-    {
+        annotations: Option<Vec<Annotation>>,
+        depends: Option<String>,
+        due: Option<Date>,
+        end: Option<Date>,
+        imask: Option<i64>,
+        mask: Option<String>,
+        modified: Option<Date>,
+        parent: Option<Uuid>,
+        priority: Option<TaskPriority>,
+        project: Option<Project>,
+        recur: Option<String>,
+        scheduled: Option<Date>,
+        start: Option<Date>,
+        tags: Option<Vec<Tag>>,
+        until: Option<Date>,
+        wait: Option<Date>,
+        uda: UDA,
+    ) -> Task {
         Task {
-            id          : id,
-            status      : status,
-            uuid        : uuid,
-            entry       : entry,
-            description : description,
+            id: id,
+            status: status,
+            uuid: uuid,
+            entry: entry,
+            description: description,
 
-            annotations : annotations,
-            depends     : depends,
-            due         : due,
-            end         : end,
-            imask       : imask,
-            mask        : mask,
-            modified    : modified,
-            parent      : parent,
-            priority    : priority,
-            project     : project,
-            recur       : recur,
-            scheduled   : scheduled,
-            start       : start,
-            tags        : tags,
-            until       : until,
-            wait        : wait,
-            uda         : uda,
+            annotations: annotations,
+            depends: depends,
+            due: due,
+            end: end,
+            imask: imask,
+            mask: mask,
+            modified: modified,
+            parent: parent,
+            priority: priority,
+            project: project,
+            recur: recur,
+            scheduled: scheduled,
+            start: start,
+            tags: tags,
+            until: until,
+            wait: wait,
+            uda: uda,
         }
     }
 
@@ -614,7 +612,7 @@ impl<'de> Visitor<'de> for TaskDeserializeVisitor {
             tags,
             until,
             wait,
-            uda
+            uda,
         );
 
         Ok(task)
@@ -628,11 +626,11 @@ mod test {
     use status::TaskStatus;
     use task::Task;
     use annotation::Annotation;
+    use uda::UDAValue;
 
     use uuid::Uuid;
     use chrono::NaiveDateTime;
     use serde_json;
-    use uda::UDAValue;
 
     fn mklogger() {
         use env_logger;
@@ -647,8 +645,7 @@ mod test {
 
     #[test]
     fn test_deser() {
-        let s =
-r#"{
+        let s = r#"{
 "id": 1,
 "description": "test",
 "entry": "20150619T165438Z",
@@ -661,12 +658,14 @@ r#"{
         let task = serde_json::from_str(s);
         println!("{:?}", task);
         assert!(task.is_ok());
-        let task : Task = task.unwrap();
+        let task: Task = task.unwrap();
 
         assert!(task.status().clone() == TaskStatus::Waiting);
         assert!(task.description() == "test");
         assert!(task.entry().clone() == mkdate("20150619T165438Z"));
-        assert!(task.uuid().clone() == Uuid::parse_str("8ca953d5-18b4-4eb9-bd56-18f2e5b752f0").unwrap());
+        assert!(
+            task.uuid().clone() == Uuid::parse_str("8ca953d5-18b4-4eb9-bd56-18f2e5b752f0").unwrap()
+        );
 
         let back = serde_json::to_string(&task).unwrap();
 
@@ -683,8 +682,7 @@ r#"{
     #[test]
     fn test_deser_more() {
         mklogger();
-        let s =
-r#"{
+        let s = r#"{
 "id": 1,
 "description": "some description",
 "entry": "20150619T165438Z",
@@ -702,24 +700,27 @@ r#"{
         let task = serde_json::from_str(s);
         println!("{:?}", task);
         assert!(task.is_ok());
-        let task : Task = task.unwrap();
+        let task: Task = task.unwrap();
 
         assert!(task.status().clone() == TaskStatus::Waiting);
         assert!(task.description() == "some description");
         assert!(task.entry().clone() == mkdate("20150619T165438Z"));
-        assert!(task.uuid().clone() == Uuid::parse_str("8ca953d5-18b4-4eb9-bd56-18f2e5b752f0").unwrap());
+        assert!(
+            task.uuid().clone() == Uuid::parse_str("8ca953d5-18b4-4eb9-bd56-18f2e5b752f0").unwrap()
+        );
 
         assert!(task.modified() == Some(&mkdate("20160327T164007Z")));
         assert!(task.project() == Some(&String::from("someproject")));
 
         if let Some(tags) = task.tags() {
             for tag in tags {
-                let any_tag = [ "some", "tags", "are", "here", ]
-                    .into_iter().any(|t| tag == *t);
+                let any_tag = ["some", "tags", "are", "here"].into_iter().any(
+                    |t| tag == *t,
+                );
                 assert!(any_tag, "Tag {} missing", tag);
             }
         } else {
-                assert!(false, "Tags completely missing");
+            assert!(false, "Tags completely missing");
         }
 
         assert!(task.wait() == Some(&mkdate("20160508T164007Z")));
@@ -746,8 +747,7 @@ r#"{
 
     #[test]
     fn test_deser_annotation() {
-        let s =
-r#"{
+        let s = r#"{
 "id":192,
 "description":"Some long description for a task",
 "entry":"20160423T125820Z",
@@ -768,13 +768,17 @@ r#"{
         let task = serde_json::from_str(s);
         println!("{:?}", task);
         assert!(task.is_ok());
-        let task : Task = task.unwrap();
+        let task: Task = task.unwrap();
 
-        let all_annotations = vec![
-            Annotation::new(mkdate("20160423T125911Z"), String::from("An Annotation")),
-            Annotation::new(mkdate("20160423T125926Z"), String::from("Another Annotation")),
-            Annotation::new(mkdate("20160422T125942Z"), String::from("A Third Anno"))
-        ];
+        let all_annotations =
+            vec![
+                Annotation::new(mkdate("20160423T125911Z"), String::from("An Annotation")),
+                Annotation::new(
+                    mkdate("20160423T125926Z"),
+                    String::from("Another Annotation")
+                ),
+                Annotation::new(mkdate("20160422T125942Z"), String::from("A Third Anno")),
+            ];
 
         if let Some(annotations) = task.annotations() {
             for annotation in annotations {
@@ -848,4 +852,3 @@ r#"{
     }
 
 }
-


### PR DESCRIPTION
This change just applies rustfmt to all files.
This should create the same binary.

Should only be applied after #58.