### PR TITLE
Simplify the types for UDAs

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -815,17 +815,17 @@ mod test {
         assert!(task.is_ok());
         let task: Task = task.unwrap();
 
-        let str_uda = task.uda().get(&"test_str_uda".into());
+        let str_uda = task.uda().get(&"test_str_uda".to_owned());
         assert!(str_uda.is_some());
         let str_uda = str_uda.unwrap();
         assert_eq!(str_uda, &UDAValue::Str("test_str_uda_value".to_owned()));
 
-        let float_uda = task.uda().get(&"test_float_uda".into());
+        let float_uda = task.uda().get(&"test_float_uda".to_owned());
         assert!(float_uda.is_some());
         let float_uda = float_uda.unwrap();
         assert_eq!(float_uda, &UDAValue::F64(-17.1234));
 
-        let int_uda = task.uda().get(&"test_int_uda".into());
+        let int_uda = task.uda().get(&"test_int_uda".to_owned());
         assert!(int_uda.is_some());
         let int_uda = int_uda.unwrap();
         assert_eq!(int_uda, &UDAValue::U64(1234));

--- a/src/uda.rs
+++ b/src/uda.rs
@@ -1,7 +1,5 @@
 //! Module containing the types for User Defined Attributes (UDA)
 
-use std::ops::{Deref, DerefMut};
-use std::default::Default;
 use std::collections::BTreeMap;
 use std::result::Result as RResult;
 use std::fmt;
@@ -13,40 +11,10 @@ use serde::Deserializer;
 use serde::de::Visitor;
 use serde::de;
 
-/// UDA Name
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
-pub struct UDAName(String);
+/// The name of a UDA is just a string.
+pub type UDAName = String;
 
-impl<'a> From<&'a str> for UDAName {
-    fn from(s: &str) -> UDAName {
-        UDAName(String::from(s))
-    }
-}
-impl From<String> for UDAName {
-    fn from(s: String) -> UDAName {
-        UDAName(s)
-    }
-}
-
-impl Serialize for UDAName {
-    fn serialize<S>(&self, serializer: S) -> RResult<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.0.serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for UDAName {
-    fn deserialize<D>(deserializer: D) -> RResult<UDAName, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        String::deserialize(deserializer).map(|s| UDAName(s))
-    }
-}
-
-/// UDA Value
+/// A UDA can have different value types.
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub enum UDAValue {
     /// UDA is a string
@@ -107,45 +75,6 @@ impl<'de> Deserialize<'de> for UDAValue {
     }
 }
 
-/// Wrapper type for BTreeMap<UDAName, UDAValue> so serde does not automatically implement the
-/// Deserialize trait on it.
-#[derive(Clone, Debug)]
-pub struct UDA(BTreeMap<UDAName, UDAValue>);
-
-impl Deref for UDA {
-    type Target = BTreeMap<UDAName, UDAValue>;
-
-    fn deref(&self) -> &BTreeMap<UDAName, UDAValue> {
-        &self.0
-    }
-}
-
-impl DerefMut for UDA {
-    fn deref_mut(&mut self) -> &mut BTreeMap<UDAName, UDAValue> {
-        &mut self.0
-    }
-}
-
-impl Default for UDA {
-    fn default() -> UDA {
-        UDA(BTreeMap::new())
-    }
-}
-
-impl Serialize for UDA {
-    fn serialize<S>(&self, serializer: S) -> RResult<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.0.serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for UDA {
-    fn deserialize<D>(deserializer: D) -> RResult<UDA, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        BTreeMap::deserialize(deserializer).map(|btm| UDA(btm))
-    }
-}
+/// The UDA Type is just a BTreeMap<UDAName, UDAValue> in which all fields of a task are saved,
+/// which are not part of the taskwarrior standard. (This makes them user defined attributes.)
+pub type UDA = BTreeMap<UDAName, UDAValue>;


### PR DESCRIPTION
I realized that the previous reasons to use the newtype pattern for UDA don't exist anymore.
Why not drop it?