### PR TITLE
[WIP] Add Taskwarrior Module

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,5 +11,9 @@ error_chain!{
         ParserError {}
         /// Error kind indicating that the Reader failed to read something
         ReaderError {}
+        /// Error kind indicating that a call to the task warrior binary failed
+        TaskCmdError {}
+        /// Error kind indicating that a conversion to JSON failed
+        SerializeError {}
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,3 +70,4 @@ pub mod status;
 pub mod tag;
 pub mod task;
 pub mod uda;
+pub mod tw;

--- a/src/tw.rs
+++ b/src/tw.rs
@@ -9,7 +9,7 @@
 //! in your path. This will always call task and never interact with your `.task` directory itself.
 //! (This is in accordance with the taskwarrior api guide lines.)
 
-use error::{Result, ResultExt};
+use error::{Result, ResultExt, ErrorKind as EK};
 use task::Task;
 use std::process::{Command, Stdio};
 use std::io::Write;
@@ -24,14 +24,12 @@ pub fn query(query: &str) -> Result<Vec<Task>> {
         cmd.arg(filter);
     }
     let mut export = cmd.arg("export").stdout(Stdio::piped()).spawn().chain_err(
-        || "Failed to start task … export.",
+        || {
+            EK::TaskCmdError
+        },
     )?;
-    export.wait().chain_err(
-        || "Failed to wait for task … export to finish",
-    )?;
-    import(export.stdout.chain_err(
-        || "Failed to capture stdout of task … export",
-    )?)
+    export.wait().chain_err(|| EK::TaskCmdError)?;
+    import(export.stdout.chain_err(|| EK::TaskCmdError)?)
 }
 
 /// This will save the given tasks to taskwarrior. Call with `Some(task)` if you just have one
@@ -40,21 +38,21 @@ pub fn save<T>(tasks: T) -> Result<()>
 where
     T: IntoIterator<Item = Task>,
 {
-    let import = Command::new("task")
+    let tasks: Vec<Task> = tasks.into_iter().collect();
+    let input_buffer = serde_json::to_string(&tasks).chain_err(
+        || EK::SerializeError,
+    )?;
+    let mut import = Command::new("task")
         .arg("import")
         .stdin(Stdio::piped())
         .spawn()
-        .chain_err(|| "Failed to spawn task … import")?;
+        .chain_err(|| EK::TaskCmdError)?;
     import
         .stdin
-        .chain_err(|| "Failed to grap stdin of task import")?
-        .write_all(
-            serde_json::to_string(&tasks.into_iter().collect::<Vec<_>>())
-                .chain_err(|| "Failed to Serialize")?
-                .as_bytes(),
-        )
-        .chain_err(
-            || "Failed to write serialized tasks to stdin of task import",
-        )?;
+        .as_mut()
+        .chain_err(|| EK::TaskCmdError)?
+        .write_all(input_buffer.as_bytes())
+        .chain_err(|| EK::TaskCmdError)?;
+    import.wait().chain_err(|| EK::TaskCmdError)?;
     Ok(())
 }

--- a/src/tw.rs
+++ b/src/tw.rs
@@ -1,0 +1,60 @@
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+
+//! This module offers functions to interact with taskwarrior. This will expect the `task` binary
+//! in your path. This will always call task and never interact with your `.task` directory itself.
+//! (This is in accordance with the taskwarrior api guide lines.)
+
+use error::{Result, ResultExt};
+use task::Task;
+use std::process::{Command, Stdio};
+use std::io::Write;
+use import::import;
+use serde_json;
+
+/// This will give you all tasks which match the given query in the taskwarrior query syntax.
+/// This is not sanitized. Never get the query string from an untrusted user.
+pub fn query(query: &str) -> Result<Vec<Task>> {
+    let mut cmd = Command::new("task");
+    for filter in query.split_whitespace() {
+        cmd.arg(filter);
+    }
+    let mut export = cmd.arg("export").stdout(Stdio::piped()).spawn().chain_err(
+        || "Failed to start task … export.",
+    )?;
+    export.wait().chain_err(
+        || "Failed to wait for task … export to finish",
+    )?;
+    import(export.stdout.chain_err(
+        || "Failed to capture stdout of task … export",
+    )?)
+}
+
+/// This will save the given tasks to taskwarrior. Call with `Some(task)` if you just have one
+/// task.
+pub fn save<T>(tasks: T) -> Result<()>
+where
+    T: IntoIterator<Item = Task>,
+{
+    let import = Command::new("task")
+        .arg("import")
+        .stdin(Stdio::piped())
+        .spawn()
+        .chain_err(|| "Failed to spawn task … import")?;
+    import
+        .stdin
+        .chain_err(|| "Failed to grap stdin of task import")?
+        .write_all(
+            serde_json::to_string(&tasks.into_iter().collect::<Vec<_>>())
+                .chain_err(|| "Failed to Serialize")?
+                .as_bytes(),
+        )
+        .chain_err(
+            || "Failed to write serialized tasks to stdin of task import",
+        )?;
+    Ok(())
+}


### PR DESCRIPTION
This PR will add the module tw with the functions `tw::query(query)` and `tw:save(tasks)`. They do pretty much, what you expect and are the basic ingredients for all interactions with taskwarrior. Most other interaction can probably be abstracted over this.

