### PR TITLE
Remove doclink

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,6 @@
 //! ```
 //!
 #![deny(missing_docs)]
-#![doc(html_root_url = "https://matthiasbeyer.github.io/task-hookrs/")]
 #![deny(
     dead_code,
     non_camel_case_types,


### PR DESCRIPTION
Everyone uses docs.rs anyways.
