### PR TITLE
Support taskwarrior 2.6.0 serialization format

### DIFF
--- a/examples/create_task.rs
+++ b/examples/create_task.rs
@@ -5,6 +5,7 @@ extern crate uuid;
 
 use task_hookrs::status::TaskStatus;
 use task_hookrs::task::Task;
+use task_hookrs::task::TW26;
 use task_hookrs::uda::UDA;
 
 use chrono::NaiveDateTime;
@@ -14,7 +15,7 @@ use uuid::Uuid;
 fn main() {
     let uuid = Uuid::nil();
     let date = NaiveDateTime::parse_from_str("2016-12-31 12:13:14", "%Y-%m-%d %H:%M:%S").unwrap();
-    let t = Task::new(
+    let t: Task<TW26> = Task::new(
         Some(12),
         TaskStatus::Pending,
         uuid,

--- a/examples/import_task.rs
+++ b/examples/import_task.rs
@@ -7,11 +7,12 @@ use std::io::stdin;
 
 use task_hookrs::import::import;
 use task_hookrs::status::TaskStatus;
+use task_hookrs::task::Task;
 
 fn main() {
     let mut tasks = import(stdin()).unwrap();
     assert_eq!(tasks.len(), 1);
-    let t = tasks.pop().unwrap();
+    let t: Task = tasks.pop().unwrap();
     assert_eq!(*t.status(), TaskStatus::Pending);
     assert_eq!(*t.description(), "Test task".to_owned());
     assert_eq!(t.priority(), None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,10 @@
 //! ```
 //!   use std::io::stdin;
 //!
-//!   use task_hookrs::task::Task;
+//!   use task_hookrs::task::{Task, TW26};
 //!   use task_hookrs::import::import;
 //!
-//!   if let Ok(tasks) = import(stdin()) {
+//!   if let Ok(tasks) = import::<TW26, _>(stdin()) {
 //!       for task in tasks {
 //!           println!("Task: {}, entered {:?} is {} -> {}",
 //!                     task.uuid(),


### PR DESCRIPTION
As discussed over email opening this PR over github.

This adds support for the new (>2.6.0) while maintaining support for the legacy (<2.5.3) (de)serialization formats for taskwarrior