### PR TITLE
Prepare 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This changelog was started with the 0.4.0 release.
 
 ## Next
 
+## 0.9.0
+
+* Support for taskwarrior 2.6.0 serialization format
+* MSRV was updated to 1.63.0
+
 ## 0.8.0
 
 * Replace "failure" with "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "task-hookrs"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>",
            "Mario Krehl <mario-krehl@gmx.de>",
            "Malte Brandy <malte.brandy@maralorn.de>",


### PR DESCRIPTION
In #27 we said that it might be good to have a new release for the taskwarrior 2.6.0 serialization format.

This prepares the release.